### PR TITLE
Fixed local demo to include generate_crypto step

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,14 @@ FogROS2-SGC is a cloud robotics platform for connecting disjoint ROS2 networks a
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Local Demo 
-If you want to get a taste of FogROS2 SGC without setting up the environment, just run 
+If you want to get a taste of FogROS2 SGC without setting up the environment, generate keys locally (they will be mounted in docker compose):
+
+```
+cd scripts
+./generate_crypto.sh
+```
+
+Then just run:
 ```
 docker compose build && docker compose up 
 ```


### PR DESCRIPTION
Docker compose mounts local "scripts" folder, including certs/keys.
Hence certs/keys need to be locally generated before launching the composition.

Failure to do so results in both talker and listener failing with: 

```
talker-1        | The application panicked (crashed).
talker-1        |   crypto file not found!: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```